### PR TITLE
fix: Input fields to have expected behaviour in case of empty / only whitespaces string

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/EmailFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/EmailFieldInput.tsx
@@ -27,30 +27,30 @@ export const EmailFieldInput = ({
   const persistField = usePersistField();
 
   const handleEnter = (newText: string) => {
-    onEnter?.(() => persistField(newText));
+    onEnter?.(() => persistField(newText.trim()));
   };
 
   const handleEscape = (newText: string) => {
-    onEscape?.(() => persistField(newText));
+    onEscape?.(() => persistField(newText.trim()));
   };
 
   const handleClickOutside = (
     event: MouseEvent | TouchEvent,
     newText: string,
   ) => {
-    onClickOutside?.(() => persistField(newText));
+    onClickOutside?.(() => persistField(newText.trim()));
   };
 
   const handleTab = (newText: string) => {
-    onTab?.(() => persistField(newText));
+    onTab?.(() => persistField(newText.trim()));
   };
 
   const handleShiftTab = (newText: string) => {
-    onShiftTab?.(() => persistField(newText));
+    onShiftTab?.(() => persistField(newText.trim()));
   };
 
   const handleChange = (newText: string) => {
-    setDraftValue(newText);
+    setDraftValue(newText.trim());
   };
 
   return (

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/FullNameFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/FullNameFieldInput.tsx
@@ -34,8 +34,8 @@ export const FullNameFieldInput = ({
 
   const convertToFullName = (newDoubleText: FieldDoubleText) => {
     return {
-      firstName: newDoubleText.firstValue,
-      lastName: newDoubleText.secondValue,
+      firstName: newDoubleText.firstValue.trim(),
+      lastName: newDoubleText.secondValue.trim(),
     };
   };
 

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/FullNameFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/FullNameFieldInput.tsx
@@ -32,6 +32,12 @@ export const FullNameFieldInput = ({
 
   const persistField = usePersistField();
 
+  const isTrimmedFieldDoubleTextEmpty = (newDoubleText: FieldDoubleText) => {
+    const { firstValue, secondValue } = newDoubleText;
+    const totalLength = firstValue.trim().length + secondValue.trim().length;
+    return totalLength ? false : true;
+  };
+
   const convertToFullName = (newDoubleText: FieldDoubleText) => {
     return {
       firstName: newDoubleText.firstValue.trim(),
@@ -39,35 +45,55 @@ export const FullNameFieldInput = ({
     };
   };
 
+  const getRequiredValuetoPersistFromDoubleText = (
+    newDoubleText: FieldDoubleText,
+  ) => {
+    return isTrimmedFieldDoubleTextEmpty(newDoubleText)
+      ? undefined
+      : convertToFullName(newDoubleText);
+  };
+
   const handleEnter = (newDoubleText: FieldDoubleText) => {
-    onEnter?.(() => persistField(convertToFullName(newDoubleText)));
+    onEnter?.(() =>
+      persistField(getRequiredValuetoPersistFromDoubleText(newDoubleText)),
+    );
   };
 
   const handleEscape = (newDoubleText: FieldDoubleText) => {
-    onEscape?.(() => persistField(convertToFullName(newDoubleText)));
+    onEscape?.(() =>
+      persistField(getRequiredValuetoPersistFromDoubleText(newDoubleText)),
+    );
   };
 
   const handleClickOutside = (
     event: MouseEvent | TouchEvent,
     newDoubleText: FieldDoubleText,
   ) => {
-    onClickOutside?.(() => persistField(convertToFullName(newDoubleText)));
+    onClickOutside?.(() =>
+      persistField(getRequiredValuetoPersistFromDoubleText(newDoubleText)),
+    );
   };
 
   const handleTab = (newDoubleText: FieldDoubleText) => {
-    onTab?.(() => persistField(convertToFullName(newDoubleText)));
+    onTab?.(
+      () => () =>
+        persistField(getRequiredValuetoPersistFromDoubleText(newDoubleText)),
+    );
   };
 
   const handleShiftTab = (newDoubleText: FieldDoubleText) => {
-    onShiftTab?.(() => persistField(convertToFullName(newDoubleText)));
+    onShiftTab?.(
+      () => () =>
+        persistField(getRequiredValuetoPersistFromDoubleText(newDoubleText)),
+    );
   };
 
   const handleChange = (newDoubleText: FieldDoubleText) => {
-    setDraftValue(convertToFullName(newDoubleText));
+    setDraftValue(getRequiredValuetoPersistFromDoubleText(newDoubleText));
   };
 
   const handlePaste = (newDoubleText: FieldDoubleText) => {
-    setDraftValue(convertToFullName(newDoubleText));
+    setDraftValue(getRequiredValuetoPersistFromDoubleText(newDoubleText));
   };
 
   return (

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/TextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/TextFieldInput.tsx
@@ -4,6 +4,8 @@ import { TextAreaInput } from '@/ui/field/input/components/TextAreaInput';
 import { usePersistField } from '../../../hooks/usePersistField';
 import { useTextField } from '../../hooks/useTextField';
 
+import { convertToEmptyStringForWhitespaces } from '~/utils/string/convertToEmptyStringForWhitespaces';
+import { convertToUndefinedForWhitespaces } from '~/utils/string/convertToUndefinedForWhitespaces';
 import { FieldInputEvent } from './DateTimeFieldInput';
 
 export type TextFieldInputProps = {
@@ -27,35 +29,35 @@ export const TextFieldInput = ({
   const persistField = usePersistField();
 
   const handleEnter = (newText: string) => {
-    onEnter?.(() => persistField(newText));
+    // have change like handleChange here too
+    onEnter?.(() => persistField(convertToEmptyStringForWhitespaces(newText)));
   };
 
   const handleEscape = (newText: string) => {
-    onEscape?.(() => persistField(newText));
+    onEscape?.(() => persistField(convertToEmptyStringForWhitespaces(newText)));
   };
 
   const handleClickOutside = (
     event: MouseEvent | TouchEvent,
     newText: string,
   ) => {
-    onClickOutside?.(() => persistField(newText));
+    onClickOutside?.(() =>
+      persistField(convertToEmptyStringForWhitespaces(newText)),
+    );
   };
 
   const handleTab = (newText: string) => {
-    onTab?.(() => persistField(newText));
+    onTab?.(() => persistField(convertToEmptyStringForWhitespaces(newText)));
   };
 
   const handleShiftTab = (newText: string) => {
-    onShiftTab?.(() => persistField(newText));
+    onShiftTab?.(() =>
+      persistField(convertToEmptyStringForWhitespaces(newText)),
+    );
   };
 
   const handleChange = (newText: string) => {
-    // draft value when string getting "" isn't resettings to undefined -> need to have a look on how this can be generalised and when to put.
-    if (newText.trim() === '') {
-      setDraftValue(undefined);
-    } else {
-      setDraftValue(newText);
-    }
+    setDraftValue(convertToUndefinedForWhitespaces(newText));
   };
 
   return (

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/TextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/TextFieldInput.tsx
@@ -50,7 +50,12 @@ export const TextFieldInput = ({
   };
 
   const handleChange = (newText: string) => {
-    setDraftValue(newText);
+    // draft value when string getting "" isn't resettings to undefined -> need to have a look on how this can be generalised and when to put.
+    if (newText.trim() === '') {
+      setDraftValue(undefined);
+    } else {
+      setDraftValue(newText);
+    }
   };
 
   return (

--- a/packages/twenty-front/src/modules/ui/input/components/TextInputV2.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/TextInputV2.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react';
 import { IconComponent, IconEye, IconEyeOff } from 'twenty-ui';
 import { useCombinedRefs } from '~/hooks/useCombinedRefs';
+import { convertToEmptyStringForWhitespaces } from '~/utils/string/convertToEmptyStringForWhitespaces';
 
 const StyledContainer = styled.div<
   Pick<TextInputV2ComponentProps, 'fullWidth'>
@@ -188,7 +189,7 @@ const TextInputV2Component = (
           onBlur={onBlur}
           type={passwordVisible ? 'text' : type}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
-            onChange?.(event.target.value);
+            onChange?.(convertToEmptyStringForWhitespaces(event.target.value));
           }}
           onKeyDown={onKeyDown}
           {...{

--- a/packages/twenty-front/src/modules/workspace/components/WorkspaceInviteTeam.tsx
+++ b/packages/twenty-front/src/modules/workspace/components/WorkspaceInviteTeam.tsx
@@ -72,13 +72,16 @@ export const WorkspaceInviteTeam = () => {
   const { enqueueSnackBar } = useSnackBar();
   const { sendInvitation } = useCreateWorkspaceInvitation();
 
-  const { reset, handleSubmit, control, formState } = useForm<FormInput>({
-    mode: 'onSubmit',
-    resolver: zodResolver(validationSchema()),
-    defaultValues: {
-      emails: '',
+  const { reset, handleSubmit, control, formState, watch } = useForm<FormInput>(
+    {
+      mode: 'onSubmit',
+      resolver: zodResolver(validationSchema()),
+      defaultValues: {
+        emails: '',
+      },
     },
-  });
+  );
+  const isEmailsEmpty = !watch('emails');
 
   const submit = handleSubmit(async ({ emails }) => {
     const emailsList = sanitizeEmailList(emails.split(','));
@@ -109,7 +112,7 @@ export const WorkspaceInviteTeam = () => {
     }
   };
 
-  const { isSubmitSuccessful } = formState;
+  const { isSubmitSuccessful, errors } = formState;
 
   useEffect(() => {
     if (isSubmitSuccessful) {
@@ -144,6 +147,7 @@ export const WorkspaceInviteTeam = () => {
           accent="blue"
           title="Invite"
           type="submit"
+          disabled={isEmailsEmpty || !!errors.emails}
         />
       </StyledContainer>
     </form>

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
@@ -27,6 +27,7 @@ import { ConfirmationModal } from '@/ui/layout/modal/components/ConfirmationModa
 import { SubMenuTopBarContainer } from '@/ui/layout/page/SubMenuTopBarContainer';
 import { Section } from '@/ui/layout/section/components/Section';
 import { useGenerateApiKeyTokenMutation } from '~/generated/graphql';
+import { convertToEmptyStringForWhitespaces } from '~/utils/string/convertToEmptyStringForWhitespaces';
 
 const StyledInfo = styled.span`
   color: ${({ theme }) => theme.font.color.light};
@@ -199,8 +200,7 @@ export const SettingsDevelopersApiKeyDetail = () => {
                 apiKeyId={apiKeyData?.id}
                 disabled={loading}
                 onNameUpdate={(value: string) => {
-                  const apiKeyNameValue = value.trim().length ? value : '';
-                  setApiKeyName(apiKeyNameValue);
+                  setApiKeyName(convertToEmptyStringForWhitespaces(value));
                 }}
               />
             </Section>

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
@@ -198,7 +198,10 @@ export const SettingsDevelopersApiKeyDetail = () => {
                 apiKeyName={apiKeyName}
                 apiKeyId={apiKeyData?.id}
                 disabled={loading}
-                onNameUpdate={setApiKeyName}
+                onNameUpdate={(value: string) => {
+                  const apiKeyNameValue = value.trim().length ? value : '';
+                  setApiKeyName(apiKeyNameValue);
+                }}
               />
             </Section>
             <Section>

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -100,9 +100,10 @@ export const SettingsDevelopersApiKeysNew = () => {
               }
             }}
             onChange={(value) => {
+              const name = value.trim().length ? value : '';
               setFormValues((prevState) => ({
                 ...prevState,
-                name: value,
+                name,
               }));
             }}
             fullWidth

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -20,6 +20,7 @@ import { useSetRecoilState } from 'recoil';
 import { Key } from 'ts-key-enum';
 import { useGenerateApiKeyTokenMutation } from '~/generated/graphql';
 import { isDefined } from '~/utils/isDefined';
+import { convertToEmptyStringForWhitespaces } from '~/utils/string/convertToEmptyStringForWhitespaces';
 
 export const SettingsDevelopersApiKeysNew = () => {
   const [generateOneApiKeyToken] = useGenerateApiKeyTokenMutation();
@@ -100,10 +101,9 @@ export const SettingsDevelopersApiKeysNew = () => {
               }
             }}
             onChange={(value) => {
-              const name = value.trim().length ? value : '';
               setFormValues((prevState) => ({
                 ...prevState,
-                name,
+                name: convertToEmptyStringForWhitespaces(value),
               }));
             }}
             fullWidth

--- a/packages/twenty-front/src/pages/settings/serverless-functions/SettingsServerlessFunctionDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/serverless-functions/SettingsServerlessFunctionDetail.tsx
@@ -18,12 +18,15 @@ import { SubMenuTopBarContainer } from '@/ui/layout/page/SubMenuTopBarContainer'
 import { Section } from '@/ui/layout/section/components/Section';
 import { TabList } from '@/ui/layout/tab/components/TabList';
 import { useTabList } from '@/ui/layout/tab/hooks/useTabList';
+import { Breadcrumb } from '@/ui/navigation/bread-crumb/components/Breadcrumb';
+import isEmpty from 'lodash.isempty';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { IconCode, IconFunction, IconSettings, IconTestPipe } from 'twenty-ui';
-import { usePreventOverlapCallback } from '~/hooks/usePreventOverlapCallback';
+import { useDebouncedCallback } from 'use-debounce';
 import { isDefined } from '~/utils/isDefined';
+import { convertToEmptyStringForWhitespaces } from '~/utils/string/convertToEmptyStringForWhitespaces';
 
 const TAB_LIST_COMPONENT_ID = 'serverless-function-detail';
 
@@ -72,10 +75,10 @@ export const SettingsServerlessFunctionDetail = () => {
   const handleSave = usePreventOverlapCallback(save, 1000);
 
   const onChange = (key: string) => {
-    return async (value: string | undefined) => {
+    return async (value: string) => {
       setFormValues((prevState) => ({
         ...prevState,
-        [key]: value,
+        [key]: convertToEmptyStringForWhitespaces(value),
       }));
       await handleSave();
     };

--- a/packages/twenty-front/src/pages/settings/serverless-functions/SettingsServerlessFunctionsNew.tsx
+++ b/packages/twenty-front/src/pages/settings/serverless-functions/SettingsServerlessFunctionsNew.tsx
@@ -16,6 +16,7 @@ import { Key } from 'ts-key-enum';
 import { IconFunction } from 'twenty-ui';
 import { useHotkeyScopeOnMount } from '~/hooks/useHotkeyScopeOnMount';
 import { isDefined } from '~/utils/isDefined';
+import { convertToEmptyStringForWhitespaces } from '~/utils/string/convertToEmptyStringForWhitespaces';
 
 export const SettingsServerlessFunctionsNew = () => {
   const navigate = useNavigate();
@@ -45,10 +46,10 @@ export const SettingsServerlessFunctionsNew = () => {
   };
 
   const onChange = (key: string) => {
-    return (value: string | undefined) => {
+    return (value: string) => {
       setFormValues((prevState) => ({
         ...prevState,
-        [key]: value,
+        [key]: convertToEmptyStringForWhitespaces(value),
       }));
     };
   };

--- a/packages/twenty-front/src/utils/string/convertToEmptyStringForWhitespaces.ts
+++ b/packages/twenty-front/src/utils/string/convertToEmptyStringForWhitespaces.ts
@@ -1,0 +1,3 @@
+export const convertToEmptyStringForWhitespaces = (value: string): string => {
+  return value.trim().length ? value : '';
+};

--- a/packages/twenty-front/src/utils/string/convertToUndefinedForWhitespaces.ts
+++ b/packages/twenty-front/src/utils/string/convertToUndefinedForWhitespaces.ts
@@ -1,0 +1,5 @@
+export const convertToUndefinedForWhitespaces = (
+  value: string,
+): string | undefined => {
+  return value.trim() === '' ? undefined : value;
+};


### PR DESCRIPTION
- [x] Don't allow Empty (whitespaces) Objects to Create, all the keyboard shortcuts are also handled for this.
- [x] Api Keys Input Name Field -> New and Detail View Name field shouldn't be empty or string with whitespaces, we won't able to have whitespaces in both. Try Entering just spaces
- [x] Similar to above, Empty webhook endpoint url under /settings/developers/webhooks/new won't be created. Try Entering just spaces
- [x] New Functions or Updating Functions will not able to have whitespaces, empty string as Name. Try Entering just spaces
- [x] under settings/workspace-members changes will lead and solve that user won't be able to enter Invite by email as just whitespaces + button is now getting disabled when there is no correct email. Try Entering just spaces
- [x] Text Input Field, will not allow to start entering with whitespaces and won't take just whitespaces as value spaces between words will work.
- [x] Similarly Number works as per above including shortcuts.
- [x] Similarly FullName field works as per above including shortcuts
- [x] Pasting fullName is been Improved.